### PR TITLE
fix after compile actions again

### DIFF
--- a/docs/docs/configuration/generated_vscode_settings.md
+++ b/docs/docs/configuration/generated_vscode_settings.md
@@ -35,9 +35,9 @@ Whether to show the 'Compile Code' icon in editor title menu.
 
 _Default_: `true`
 
-## runServerCommands
+## runServerCommandsAfterCompile
 
-**sourcepawn.runServerCommands**
+**sourcepawn.runServerCommandsAfterCompile**
 
 Run RCON commands after compiling.
 
@@ -51,9 +51,9 @@ A list of commands that will be sent to the server after a successful VSCode com
 
 _Default_: `["sm plugins refresh"]`
 
-## uploadToServer
+## uploadToServerAfterCompile
 
-**sourcepawn.uploadToServer**
+**sourcepawn.uploadToServerAfterCompile**
 
 Upload files to FTP/SFTP after compiling.
 

--- a/docs/docs/configuration/generated_vscode_settings.md
+++ b/docs/docs/configuration/generated_vscode_settings.md
@@ -39,9 +39,9 @@ _Default_: `true`
 
 **sourcepawn.runServerCommands**
 
-Should the specified commands be executed on the server after a successful VSCode command or on `runServerCommands`.
+Run RCON commands after compiling.
 
-_Default_: ``
+_Default_: `"false"`
 
 ## serverCommands
 
@@ -51,11 +51,11 @@ A list of commands that will be sent to the server after a successful VSCode com
 
 _Default_: `["sm plugins refresh"]`
 
-## uploadAfterSuccessfulCompile
+## uploadToServer
 
-**sourcepawn.uploadAfterSuccessfulCompile**
+**sourcepawn.uploadToServer**
 
-Should the upload command be executed on a successful compile.
+Upload files to FTP/SFTP after compiling.
 
 _Default_: `false`
 

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -232,13 +232,9 @@
           "description": "Whether to show the 'Compile Code' icon in editor title menu."
         },
         "sourcepawn.runServerCommands": {
-          "type": "string",
-          "enum": [
-            "disabled",
-            "afterCompile",
-            "afterUpload"
-          ],
-          "description": "Should the specified commands be executed on the server after a successful VSCode command or on `runServerCommands`.",
+          "type": "boolean",
+          "default": "false",
+          "description": "Run RCON commands after compiling.",
           "scope": "resource"
         },
         "sourcepawn.serverCommands": {
@@ -249,10 +245,10 @@
           "scope": "resource",
           "description": "A list of commands that will be sent to the server after a successful VSCode command or on `runServerCommands`."
         },
-        "sourcepawn.uploadAfterSuccessfulCompile": {
+        "sourcepawn.uploadToServer": {
           "type": "boolean",
           "default": false,
-          "description": "Should the upload command be executed on a successful compile.",
+          "description": "Upload files to FTP/SFTP after compiling.",
           "scope": "resource"
         },
         "sourcepawn.enableLinter": {

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -231,7 +231,7 @@
           "default": true,
           "description": "Whether to show the 'Compile Code' icon in editor title menu."
         },
-        "sourcepawn.runServerCommands": {
+        "sourcepawn.runServerCommandsAfterCompile": {
           "type": "boolean",
           "default": "false",
           "description": "Run RCON commands after compiling.",
@@ -245,7 +245,7 @@
           "scope": "resource",
           "description": "A list of commands that will be sent to the server after a successful VSCode command or on `runServerCommands`."
         },
-        "sourcepawn.uploadToServer": {
+        "sourcepawn.uploadToServerAfterCompile": {
           "type": "boolean",
           "default": false,
           "description": "Upload files to FTP/SFTP after compiling.",

--- a/editors/code/package_template.json
+++ b/editors/code/package_template.json
@@ -232,13 +232,9 @@
           "description": "Whether to show the 'Compile Code' icon in editor title menu."
         },
         "sourcepawn.runServerCommands": {
-          "type": "string",
-          "enum": [
-            "disabled",
-            "afterCompile",
-            "afterUpload"
-          ],
-          "description": "Should the specified commands be executed on the server after a successful VSCode command or on `runServerCommands`.",
+          "type": "boolean",
+          "default": "false",
+          "description": "Run RCON commands after compiling.",
           "scope": "resource"
         },
         "sourcepawn.serverCommands": {
@@ -249,10 +245,10 @@
           "scope": "resource",
           "description": "A list of commands that will be sent to the server after a successful VSCode command or on `runServerCommands`."
         },
-        "sourcepawn.uploadAfterSuccessfulCompile": {
+        "sourcepawn.uploadToServer": {
           "type": "boolean",
           "default": false,
-          "description": "Should the upload command be executed on a successful compile.",
+          "description": "Upload files to FTP/SFTP after compiling.",
           "scope": "resource"
         },
         "sourcepawn.enableLinter": {

--- a/editors/code/package_template.json
+++ b/editors/code/package_template.json
@@ -231,7 +231,7 @@
           "default": true,
           "description": "Whether to show the 'Compile Code' icon in editor title menu."
         },
-        "sourcepawn.runServerCommands": {
+        "sourcepawn.runServerCommandsAfterCompile": {
           "type": "boolean",
           "default": "false",
           "description": "Run RCON commands after compiling.",
@@ -245,7 +245,7 @@
           "scope": "resource",
           "description": "A list of commands that will be sent to the server after a successful VSCode command or on `runServerCommands`."
         },
-        "sourcepawn.uploadToServer": {
+        "sourcepawn.uploadToServerAfterCompile": {
           "type": "boolean",
           "default": false,
           "description": "Upload files to FTP/SFTP after compiling.",

--- a/editors/code/src/Commands/compileSM.ts
+++ b/editors/code/src/Commands/compileSM.ts
@@ -159,16 +159,14 @@ export async function run(args: URI): Promise<number> {
       // Little success message in console
       output.appendLine("Compilation successful.");
 
-      let uploadSuccessful: boolean = false;
+      // Get after-compile actions
+      const uploadFtp: boolean = getConfig(Section.SourcePawn, "uploadToServer", workspaceFolder);
+      const runCommands: boolean = getConfig(Section.SourcePawn, "runServerCommands", workspaceFolder);
 
-      // Run upload command if chosen
-      if (getConfig(Section.SourcePawn, "uploadAfterSuccessfulCompile", workspaceFolder)) {
-        uploadSuccessful = await uploadToServerCommand(fileToCompilePath);
-      }
+      // Run upload and run commands in order if both are true
+      const uploadSuccessful = uploadFtp ? await uploadToServerCommand(fileToCompilePath) : true;
 
-      // Run server commands if chosen
-      const commandsOption: string = getConfig(Section.SourcePawn, "runServerCommands", workspaceFolder);
-      if (uploadSuccessful && commandsOption === "afterCompile") {
+      if (uploadSuccessful && runCommands) {
         await runServerCommands(fileToCompilePath);
       }
 

--- a/editors/code/src/Commands/uploadToServer.ts
+++ b/editors/code/src/Commands/uploadToServer.ts
@@ -23,6 +23,7 @@ export interface UploadOptions {
 export async function run(args?: string): Promise<boolean> {
   let workspaceFolder: WorkspaceFolder;
   let fileToUpload: string;
+  let success = false;
 
   // If we receive arguments, the file to upload has already been figured out for us,
   // else, we use the user's choice, main compilation file or current editor

--- a/editors/code/src/Commands/uploadToServer.ts
+++ b/editors/code/src/Commands/uploadToServer.ts
@@ -1,5 +1,4 @@
 ﻿import path from "path";
-import { run as runServerCommands } from "./runServerCommands";
 import { getMainCompilationFile } from "../spUtils";
 import { ProgressLocation, WorkspaceFolder, window, workspace as Workspace } from "vscode";
 import { lastActiveEditor } from "../spIndex";
@@ -19,6 +18,8 @@ export interface UploadOptions {
   remoteRoot: string;
   exclude: string[];
 }
+
+let success: boolean;
 
 export async function run(args?: string): Promise<boolean> {
   let workspaceFolder: WorkspaceFolder;
@@ -100,7 +101,7 @@ export async function run(args?: string): Promise<boolean> {
 
           // Show success message
           window.showInformationMessage('Files uploaded successfully!');
-          return true;
+          success = true;
         }
         else {
           const ftp = new Client();
@@ -141,24 +142,19 @@ export async function run(args?: string): Promise<boolean> {
           window.showInformationMessage('Files uploaded successfully!');
           ftp.close();
 
-          // Run commands if configured
-          if (getConfig(Section.SourcePawn, "runServerCommands", workspaceFolder) === "afterUpload") {
-            await runServerCommands(fileToUpload);
-          }
-
-          return true;
+          success = true;
         }
       }
       catch (error) {
         if (!token.isCancellationRequested) {
           window.showErrorMessage('Failed to upload files! ' + error);
         }
-        return false;
+        success = false;
       }
       finally {
         client.end();
       }
     }
   );
-  return true;
+  return success;
 }

--- a/editors/code/src/Commands/uploadToServer.ts
+++ b/editors/code/src/Commands/uploadToServer.ts
@@ -19,7 +19,6 @@ export interface UploadOptions {
   exclude: string[];
 }
 
-let success: boolean;
 
 export async function run(args?: string): Promise<boolean> {
   let workspaceFolder: WorkspaceFolder;


### PR DESCRIPTION
I think I finally got this right after giving it more than 5 minutes of thought.

- Changed `uploadAfterSuccessfulCompile` to `uploadToServer`
- Changed `runServerCommands` from `enum` to `boolean`
- If both `runServerCommands` and `uploadToServer` options are set to true, they will execute in order, meaning `runServerCommands` won't run if `uploadToServer` doesn't return `true`, meaning a successful upload.
- Otherwise, those commands are successfully executed based on their boolean value specified in the config.